### PR TITLE
Make yajl-rails work with the modern yajl-ruby API and Rails 2.3.10

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,2 @@
-require 'yajl'
 require 'yajl_rails'
 ActiveSupport::JSON.backend = YajlRails

--- a/lib/yajl_rails.rb
+++ b/lib/yajl_rails.rb
@@ -1,18 +1,14 @@
+require 'yajl'
 require 'stringio'
 
-module ActiveSupport::JSON
-  ParseError = Yajl::ParseError
-end
-  
 module YajlRails
   extend self
 
+  ParseError = Yajl::ParseError
+
   # Converts a JSON string into a Ruby object.
   def decode(json)
-    if !json.respond_to?(:read)
-      json = StringIO.new(json)
-    end
-    data = ::Yajl::Stream.parse(json)
+    data = Yajl::Parser.parse(json)
     if ActiveSupport.parse_json_times
       convert_dates_from(data)
     else


### PR DESCRIPTION
the AS encoder is better encapsulated now, and yajl-ruby has a totally different API.
